### PR TITLE
Feat: Add Error Event Queue

### DIFF
--- a/Inc/tuk/can_wrapper/can_wrapper.h
+++ b/Inc/tuk/can_wrapper/can_wrapper.h
@@ -14,6 +14,7 @@
 
 #include "can_command_list.h"
 #include "can_message.h"
+#include "error_queue.h"
 #include <stdbool.h>
 #include <stm32l4xx.h>
 #include <stm32l4xx_hal_can.h>
@@ -34,23 +35,6 @@ typedef enum
 	CAN_WRAPPER_FAILED_TO_ENABLE_INTERRUPT,
 	CAN_WRAPPER_FAILED_TO_START_TIMER,
 } CANWrapper_StatusTypeDef;
-
-typedef struct
-{
-	enum
-	{
-		CAN_WRAPPER_ERROR_TIMEOUT = 0,
-		CAN_WRAPPER_ERROR_CAN_TIMEOUT,
-	} error;
-	union
-	{
-		struct {
-			CANMessage msg;
-			NodeID recipient;
-		};
-		// TODO: more error information.
-	};
-} CANWrapper_ErrorInfo;
 
 typedef void (*CANMessageCallback)(CANMessage, NodeID, bool);
 typedef void (*CANErrorCallback)(CANWrapper_ErrorInfo);

--- a/Inc/tuk/can_wrapper/can_wrapper.h
+++ b/Inc/tuk/can_wrapper/can_wrapper.h
@@ -4,6 +4,7 @@
  * transmission.
  *
  * @author Logan Furedi <logan.furedi@umsats.ca>
+ * @author Arnav Gupta <arnav.gupta@umsats.ca>
  *
  * @date February 27, 2024
  */

--- a/Inc/tuk/can_wrapper/can_wrapper.h
+++ b/Inc/tuk/can_wrapper/can_wrapper.h
@@ -15,6 +15,7 @@
 #include "can_command_list.h"
 #include "can_message.h"
 #include "error_queue.h"
+
 #include <stdbool.h>
 #include <stm32l4xx.h>
 #include <stm32l4xx_hal_can.h>

--- a/Inc/tuk/can_wrapper/can_wrapper.h
+++ b/Inc/tuk/can_wrapper/can_wrapper.h
@@ -74,11 +74,18 @@ typedef struct
 CANWrapper_StatusTypeDef CANWrapper_Init(CANWrapper_InitTypeDef init_struct);
 
 /**
- * @brief               Polls for new events such as new messages or errors.
+ * @brief               Polls for new messages.
  *
- * This is the point where callback functions will be triggered.
+ * This is the point where message_callback will be triggered.
  */
-CANWrapper_StatusTypeDef CANWrapper_Poll_Events();
+CANWrapper_StatusTypeDef CANWrapper_Poll_Messages();
+
+/**
+ * @brief               Polls for new errors.
+ *
+ * This is the point where error_callback will be triggered.
+ */
+CANWrapper_StatusTypeDef CANWrapper_Poll_Errors();
 
 /**
  * @brief               Sends a message over CAN.

--- a/Inc/tuk/can_wrapper/error_info.h
+++ b/Inc/tuk/can_wrapper/error_info.h
@@ -1,0 +1,31 @@
+/**
+ * @file error_info.h
+ *
+ * @author Logan Furedi <logan.furedi@umsats.ca>
+ *
+ * @date Aug 4, 2024
+ */
+
+#ifndef TSAT_UTILITIES_KIT_INC_TUK_CAN_WRAPPER_ERROR_INFO_H_
+#define TSAT_UTILITIES_KIT_INC_TUK_CAN_WRAPPER_ERROR_INFO_H_
+
+#include "can_message.h"
+
+typedef struct
+{
+	enum
+	{
+		CAN_WRAPPER_ERROR_TIMEOUT = 0,
+		CAN_WRAPPER_ERROR_CAN_TIMEOUT,
+	} error;
+	union
+	{
+		struct {
+			CANMessage msg;
+			NodeID recipient;
+		};
+		// TODO: more error information.
+	};
+} CANWrapper_ErrorInfo;
+
+#endif /* TSAT_UTILITIES_KIT_INC_TUK_CAN_WRAPPER_ERROR_INFO_H_ */

--- a/Inc/tuk/can_wrapper/error_queue.h
+++ b/Inc/tuk/can_wrapper/error_queue.h
@@ -13,6 +13,8 @@
 #ifndef CAN_WRAPPER_MODULE_INC_ERROR_QUEUE_H_
 #define CAN_WRAPPER_MODULE_INC_ERROR_QUEUE_H_
 
+#include "error_info.h"
+
 #include <stdbool.h>
 #include <sys/_stdint.h>
 
@@ -24,23 +26,6 @@ typedef struct
     uint32_t tail;
     CANWrapper_ErrorInfo items[ERROR_QUEUE_SIZE];
 } ErrorQueue;
-
-typedef struct
-{
-	enum
-	{
-		CAN_WRAPPER_ERROR_TIMEOUT = 0,
-		CAN_WRAPPER_ERROR_CAN_TIMEOUT,
-	} error;
-	union
-	{
-		struct {
-			CANMessage msg;
-			NodeID recipient;
-		};
-		// TODO: more error information.
-	};
-} CANWrapper_ErrorInfo;
 
 /**
  * @brief               Creates an empty error queue.

--- a/Inc/tuk/can_wrapper/error_queue.h
+++ b/Inc/tuk/can_wrapper/error_queue.h
@@ -13,7 +13,6 @@
 #ifndef CAN_WRAPPER_MODULE_INC_ERROR_QUEUE_H_
 #define CAN_WRAPPER_MODULE_INC_ERROR_QUEUE_H_
 
-#include "can_wrapper.h"
 #include <stdbool.h>
 #include <sys/_stdint.h>
 
@@ -25,6 +24,23 @@ typedef struct
     uint32_t tail;
     CANWrapper_ErrorInfo items[ERROR_QUEUE_SIZE];
 } ErrorQueue;
+
+typedef struct
+{
+	enum
+	{
+		CAN_WRAPPER_ERROR_TIMEOUT = 0,
+		CAN_WRAPPER_ERROR_CAN_TIMEOUT,
+	} error;
+	union
+	{
+		struct {
+			CANMessage msg;
+			NodeID recipient;
+		};
+		// TODO: more error information.
+	};
+} CANWrapper_ErrorInfo;
 
 /**
  * @brief               Creates an empty error queue.

--- a/Inc/tuk/can_wrapper/error_queue.h
+++ b/Inc/tuk/can_wrapper/error_queue.h
@@ -45,7 +45,7 @@ bool ErrorQueue_IsFull(const ErrorQueue* queue);
  * @brief               Enqueues an error into the given queue.
  *
  * @param queue         The error queue.
- * @param message       The error to enqueue.
+ * @param error         The error to enqueue.
  * @return              true on success. false on fail.
  */
 bool ErrorQueue_Enqueue(ErrorQueue* queue, CANWrapper_ErrorInfo error);
@@ -54,7 +54,7 @@ bool ErrorQueue_Enqueue(ErrorQueue* queue, CANWrapper_ErrorInfo error);
  * @brief:              Dequeues an error out of the given queue.
  *
  * @param queue         The error queue.
- * @param out_message   The output location for error.
+ * @param out_error     The output location for the error.
  * @return              true on success. false on fail.
  */
 bool ErrorQueue_Dequeue(ErrorQueue* queue, CANWrapper_ErrorInfo* out_error);

--- a/Inc/tuk/can_wrapper/error_queue.h
+++ b/Inc/tuk/can_wrapper/error_queue.h
@@ -1,0 +1,62 @@
+/**
+ * @file error_queue.h
+ * Queue ADT for storing transmission errors.
+ * Implemented using circular buffer.
+ *
+ * @author Logan Furedi <logan.furedi@umsats.ca>
+ * @author Om Sevak <om.sevak@umsats.ca>
+ * @author Arnav Gupta <arnav.gupta@umsats.ca>
+ *
+ * @date August 3, 2024
+ */
+
+#ifndef CAN_WRAPPER_MODULE_INC_ERROR_QUEUE_H_
+#define CAN_WRAPPER_MODULE_INC_ERROR_QUEUE_H_
+
+#include "can_wrapper.h"
+#include <stdbool.h>
+#include <sys/_stdint.h>
+
+#define ERROR_QUEUE_SIZE 100
+
+typedef struct
+{
+    uint32_t head;
+    uint32_t tail;
+    CANWrapper_ErrorInfo items[ERROR_QUEUE_SIZE];
+} ErrorQueue;
+
+/**
+ * @brief               Creates an empty error queue.
+ */
+ErrorQueue ErrorQueue_Create();
+
+/**
+ * @brief               Returns true if the given queue is empty.
+ */
+bool ErrorQueue_IsEmpty(const ErrorQueue* queue);
+
+/**
+ * @brief               Returns true if the given queue is full.
+ */
+bool ErrorQueue_IsFull(const ErrorQueue* queue);
+
+/**
+ * @brief               Enqueues an error into the given queue.
+ *
+ * @param queue         The error queue.
+ * @param message       The error to enqueue.
+ * @return              true on success. false on fail.
+ */
+bool ErrorQueue_Enqueue(ErrorQueue* queue, CANWrapper_ErrorInfo error);
+
+/**
+ * @brief:              Dequeues an error out of the given queue.
+ *
+ * @param queue         The error queue.
+ * @param out_message   The output location for error.
+ * @return              true on success. false on fail.
+ */
+bool ErrorQueue_Dequeue(ErrorQueue* queue, CANWrapper_ErrorInfo* out_error);
+
+#endif /* CAN_WRAPPER_MODULE_INC_ERROR_QUEUE_H_ */

--- a/Src/can_wrapper/can_wrapper.c
+++ b/Src/can_wrapper/can_wrapper.c
@@ -86,7 +86,7 @@ CANWrapper_StatusTypeDef CANWrapper_Init(CANWrapper_InitTypeDef init_struct)
 	return CAN_WRAPPER_HAL_OK;
 }
 
-CANWrapper_StatusTypeDef CANWrapper_Poll_Events()
+CANWrapper_StatusTypeDef CANWrapper_Poll_Messages()
 {
 	if (!s_init) return CAN_WRAPPER_NOT_INITIALISED;
 
@@ -106,6 +106,13 @@ CANWrapper_StatusTypeDef CANWrapper_Poll_Events()
 			s_init_struct.message_callback(queue_item.msg.msg, queue_item.msg.sender, queue_item.msg.is_ack);
 		}
 	}
+
+	return CAN_WRAPPER_HAL_OK;
+}
+
+CANWrapper_StatusTypeDef CANWrapper_Poll_Errors()
+{
+	if (!s_init) return CAN_WRAPPER_NOT_INITIALISED;
 
 	// Poll transmission timeout events.
 	// TODO: Needs serious cleaning up.

--- a/Src/can_wrapper/can_wrapper.c
+++ b/Src/can_wrapper/can_wrapper.c
@@ -9,10 +9,11 @@
  */
 
 #include <stddef.h>
-#include <tuk/can_wrapper/can_queue.h>
-#include <tuk/can_wrapper/error_queue.h>
-#include <tuk/can_wrapper/can_wrapper.h>
-#include <tuk/can_wrapper/tx_cache.h>
+
+#include "tuk/can_wrapper/can_queue.h"
+#include "tuk/can_wrapper/error_queue.h"
+#include "tuk/can_wrapper/can_wrapper.h"
+#include "tuk/can_wrapper/tx_cache.h"
 
 #define ACK_MASK       0b00000000001
 #define RECIPIENT_MASK 0b00000000110
@@ -27,7 +28,7 @@ static CANWrapper_InitTypeDef s_init_struct = {0};
 
 static CANQueue s_msg_queue = {0};
 static TxCache s_tx_cache = {0};
-static ErrorQueue s_err_queue = {0};
+static ErrorQueue s_error_queue = {0};
 
 static bool s_init = false;
 
@@ -79,7 +80,7 @@ CANWrapper_StatusTypeDef CANWrapper_Init(CANWrapper_InitTypeDef init_struct)
 
 	s_msg_queue = CANQueue_Create();
 	s_tx_cache = TxCache_Create();
-	s_err_queue = ErrorQueue_Create();
+	s_error_queue = ErrorQueue_Create();
 
 	s_init_struct = init_struct;
 
@@ -151,7 +152,7 @@ CANWrapper_StatusTypeDef CANWrapper_Poll_Errors()
 
 	// Report queued errors
 	CANWrapper_ErrorInfo error;
-	while (ErrorQueue_Dequeue(&s_err_queue, &error))
+	while (ErrorQueue_Dequeue(&s_error_queue, &error))
 	{
 		s_init_struct.error_callback(error);
 	}

--- a/Src/can_wrapper/can_wrapper.c
+++ b/Src/can_wrapper/can_wrapper.c
@@ -127,8 +127,12 @@ CANWrapper_StatusTypeDef CANWrapper_Poll_Errors()
 		uint64_t tx_tick = front_item->timestamp.counter_value + front_item->timestamp.rcr_value*PERIOD_TICKS;
 		uint64_t timeout_tick = (tx_tick + TIMEOUT) % (16*PERIOD_TICKS);
 
-		if (tx_tick < timeout_tick ? (current_tick >= timeout_tick || current_tick < tx_tick)
-				: (current_tick >= timeout_tick && current_tick < tx_tick)) // don't even try to decipher this :)
+		bool clockOverflowed = tx_tick >= timeout_tick;
+		bool timeoutOccurred = clockOverflowed ?
+				( current_tick >= timeout_tick && current_tick < tx_tick )
+			: ( current_tick >= timeout_tick || current_tick < tx_tick )
+
+		if (timeoutOccurred)
 		{
 			// timed out.
 			CANWrapper_ErrorInfo error_info;

--- a/Src/can_wrapper/can_wrapper.c
+++ b/Src/can_wrapper/can_wrapper.c
@@ -118,7 +118,7 @@ CANWrapper_StatusTypeDef CANWrapper_Poll_Events()
 		const TxCacheItem *front_item = &s_tx_cache.items[0];
 
 		uint64_t tx_tick = front_item->timestamp.counter_value + front_item->timestamp.rcr_value*PERIOD_TICKS;
-		uint64_t timeout_tick = (tx_tick + TIMEOUT) % PERIOD_TICKS;
+		uint64_t timeout_tick = (tx_tick + TIMEOUT) % (16*PERIOD_TICKS);
 
 		if (tx_tick < timeout_tick ? (current_tick >= timeout_tick || current_tick < tx_tick)
 				: (current_tick >= timeout_tick && current_tick < tx_tick)) // don't even try to decipher this :)

--- a/Src/can_wrapper/can_wrapper.c
+++ b/Src/can_wrapper/can_wrapper.c
@@ -127,12 +127,12 @@ CANWrapper_StatusTypeDef CANWrapper_Poll_Errors()
 		uint64_t tx_tick = front_item->timestamp.counter_value + front_item->timestamp.rcr_value*PERIOD_TICKS;
 		uint64_t timeout_tick = (tx_tick + TIMEOUT) % (16*PERIOD_TICKS);
 
-		bool clockOverflowed = tx_tick >= timeout_tick;
-		bool timeoutOccurred = clockOverflowed ?
+		bool clock_overflowed = tx_tick >= timeout_tick;
+		bool timeout_occurred = clock_overflowed ?
 				( current_tick >= timeout_tick && current_tick < tx_tick )
-			: ( current_tick >= timeout_tick || current_tick < tx_tick )
+			: ( current_tick >= timeout_tick || current_tick < tx_tick );
 
-		if (timeoutOccurred)
+		if (timeout_occurred)
 		{
 			CANWrapper_ErrorInfo error_info;
 			error_info.error = CAN_WRAPPER_ERROR_TIMEOUT;
@@ -152,7 +152,7 @@ CANWrapper_StatusTypeDef CANWrapper_Poll_Errors()
 	CANWrapper_ErrorInfo error;
 	while (ErrorQueue_Dequeue(&s_err_queue, &error))
 	{
-		s_init_struct.error_callback(error) // TODO: this is dangerous. could easily lead to bugs. FIX!
+		s_init_struct.error_callback(error);
 	}
 
 	return CAN_WRAPPER_HAL_OK;

--- a/Src/can_wrapper/can_wrapper.c
+++ b/Src/can_wrapper/can_wrapper.c
@@ -134,7 +134,6 @@ CANWrapper_StatusTypeDef CANWrapper_Poll_Errors()
 
 		if (timeoutOccurred)
 		{
-			// timed out.
 			CANWrapper_ErrorInfo error_info;
 			error_info.error = CAN_WRAPPER_ERROR_TIMEOUT;
 			error_info.msg = front_item->msg.msg;

--- a/Src/can_wrapper/can_wrapper.c
+++ b/Src/can_wrapper/can_wrapper.c
@@ -3,6 +3,7 @@
  * CAN wrapper for simplified message receipt & transmission.
  *
  * @author Logan Furedi <logan.furedi@umsats.ca>
+ * @author Arnav Gupta <arnav.gupta@umsats.ca>
  *
  * @date February 28, 2024
  */

--- a/Src/can_wrapper/error_queue.c
+++ b/Src/can_wrapper/error_queue.c
@@ -10,7 +10,7 @@
  * @date August 3, 2024
  */
 
-#include <tuk/can_wrapper/error_queue.h>
+#include "tuk/can_wrapper/error_queue.h"
 
 ErrorQueue ErrorQueue_Create()
 {

--- a/Src/can_wrapper/error_queue.c
+++ b/Src/can_wrapper/error_queue.c
@@ -1,0 +1,55 @@
+/**
+ * @file error_queue.c
+ * Queue ADT for storing transmission errors.
+ * Implemented using circular buffer.
+ *
+ * @author Logan Furedi <logan.furedi@umsats.ca>
+ * @author Om Sevak <om.sevak@umsats.ca>
+ * @author Arnav Gupta <arnav.gupta@umsats.ca>
+ *
+ * @date August 3, 2024
+ */
+
+#include <tuk/can_wrapper/error_queue.h>
+
+ErrorQueue ErrorQueue_Create()
+{
+	ErrorQueue queue;
+
+    queue.head = 0;
+    queue.tail = 0;
+
+    return queue;
+}
+
+bool ErrorQueue_IsEmpty(const ErrorQueue* queue)
+{
+    return queue->head == queue->tail;
+}
+
+bool ErrorQueue_IsFull(const ErrorQueue* queue)
+{
+    return (queue->tail + 1) % ERROR_QUEUE_SIZE == queue->head;
+}
+
+bool ErrorQueue_Enqueue(ErrorQueue* queue, CANWrapper_ErrorInfo item)
+{
+    if (ErrorQueue_IsFull(queue))
+        return false;
+
+    queue->items[queue->tail] = item;
+    queue->tail = (queue->tail + 1) % ERROR_QUEUE_SIZE;
+
+    return true;
+}
+
+bool ErrorQueue_Dequeue(ErrorQueue* queue, CANWrapper_ErrorInfo* out)
+{
+    if (ErrorQueue_IsEmpty(queue))
+        return false;
+
+    *out = queue->items[queue->head];
+    queue->head = (queue->head + 1) % ERROR_QUEUE_SIZE;
+
+    return true;
+}


### PR DESCRIPTION
Features:
- 
- New ErrorQueue ADT for storing CANWrapper_ErrorInfo items, based on CANQueue implementation

Changes:
- 
- Callbacks for the TX timeout errors now run after the TX cache is cleared by looping through the ErrorQueue
- `CANWrapper_Poll_Events()` is now split into `CANWrapper_Poll_Messages()` and `CANWrapper_Poll_Errors()` which can be called separately 
- Timeout detection conditional is broken into steps for readability

Fixes:
- 
- Correctly determine the timeout tick by multiplying `PERIOD_TICKS` by 16 repeats
