### PR TITLE
Feat: Add Immediate Mode

### DIFF
--- a/Inc/tuk/can_wrapper/can_wrapper.h
+++ b/Inc/tuk/can_wrapper/can_wrapper.h
@@ -59,12 +59,14 @@ typedef struct
  */
 CANWrapper_StatusTypeDef CANWrapper_Init(CANWrapper_InitTypeDef init_struct);
 
+#ifndef CWM_IMMEDIATE_MODE
 /**
  * @brief               Polls for new messages.
  *
  * This is the point where message_callback will be triggered.
  */
 CANWrapper_StatusTypeDef CANWrapper_Poll_Messages();
+#endif
 
 /**
  * @brief               Polls for new errors.


### PR DESCRIPTION
Implemented Immediate Mode. Enable it by navigating to `Project > Properties > C/C++ Build > Settings > MCU GCC Compiler > Preprocessor` and adding the symbol `CWM_IMMEDIATE_MODE`.

The original idea of putting a `#define` above the include directive won't work in this case, since it's not a header-only library.

Also fixed a few comments.