### PR TITLE
Update the CAN Command List

### DIFF
--- a/Inc/tuk/can_wrapper/can_command_list.h
+++ b/Inc/tuk/can_wrapper/can_command_list.h
@@ -13,8 +13,6 @@
 
 #include <stdint.h>
 
-#define NUM_COMMANDS 40
-
 typedef enum
 {
 	////////////////////////////////////////////
@@ -84,6 +82,8 @@ typedef enum
 	CMD_PLD_SET_TOLERANCE,
 	CMD_PLD_GET_TOLERANCE,
 	CMD_PLD_TEST_LEDS,
+
+	NUM_COMMANDS
 } CmdID;
 
 typedef struct

--- a/Inc/tuk/can_wrapper/can_command_list.h
+++ b/Inc/tuk/can_wrapper/can_command_list.h
@@ -3,6 +3,7 @@
  * Configurations for all valid command ID's.
  *
  * @author Logan Furedi <logan.furedi@umsats.ca>
+ * @author Arnav Gupta <arnav.gupta@umsats.ca>
  *
  * @date March 3, 2024
  */

--- a/Inc/tuk/can_wrapper/can_command_list.h
+++ b/Inc/tuk/can_wrapper/can_command_list.h
@@ -12,6 +12,8 @@
 
 #include <stdint.h>
 
+#define NUM_COMMANDS 40
+
 typedef enum
 {
 	////////////////////////////////////////////
@@ -81,15 +83,6 @@ typedef enum
 	CMD_PLD_SET_TOLERANCE,
 	CMD_PLD_GET_TOLERANCE,
 	CMD_PLD_TEST_LEDS,
-
-	////////////////////////////////////////////
-	/// GROUND STATION
-	////////////////////////////////////////////
-	CMD_GND_VERIFY_FLASH_TEST,
-	CMD_GND_VERIFY_MRAM_TEST,
-	CMD_GDN_VERIFY_CDH_NUM_TASKS,
-	CMD_GND_VERIFY_SAMPLE_TASK,
-	CMD_GND_VERIFY_RTC,
 } CmdID;
 
 typedef struct
@@ -98,6 +91,6 @@ typedef struct
 	uint8_t priority;
 } CmdConfig;
 
-extern const CmdConfig cmd_configs[0x70];
+extern const CmdConfig cmd_configs[NUM_COMMANDS];
 
 #endif /* CAN_WRAPPER_MODULE_INC_CAN_COMMAND_LIST_H_ */

--- a/Inc/tuk/can_wrapper/can_command_list.h
+++ b/Inc/tuk/can_wrapper/can_command_list.h
@@ -17,79 +17,79 @@ typedef enum
 	////////////////////////////////////////////
 	/// COMMON
 	////////////////////////////////////////////
-	CMD_COMM_RESET                       = 0x00,
-	CMD_COMM_PREPARE_FOR_SHUTDOWN        = 0x01,
-	CMD_COMM_GET_TELEMETRY               = 0x02,
-	CMD_COMM_SET_TELEMETRY_INTERVAL      = 0x03,
-	CMD_COMM_GET_TELEMETRY_INTERVAL      = 0x04,
-	CMD_COMM_UPDATE_START                = 0x05,
-	CMD_COMM_UPDATE_LOAD                 = 0x06,
-	CMD_COMM_UPDATE_END                  = 0x07,
+	CMD_COMM_RESET,
+	CMD_COMM_PREPARE_FOR_SHUTDOWN,
+	CMD_COMM_GET_TELEMETRY,
+	CMD_COMM_SET_TELEMETRY_INTERVAL,
+	CMD_COMM_GET_TELEMETRY_INTERVAL,
+	CMD_COMM_UPDATE_START,
+	CMD_COMM_UPDATE_LOAD,
+	CMD_COMM_UPDATE_END,
 
 	////////////////////////////////////////////
 	/// CDH
 	////////////////////////////////////////////
 	// Event Processing.
-	CMD_CDH_PROCESS_HEARTBEAT            = 0x10,
-	CMD_CDH_PROCESS_RUNTIME_ERROR        = 0x11,
-	CMD_CDH_PROCESS_COMMAND_ERROR        = 0x12,
-	CMD_CDH_PROCESS_NOTIFICATION         = 0x13,
-	CMD_CDH_PROCESS_TELEMETRY_REPORT     = 0x14,
-	CMD_CDH_PROCESS_RETURN               = 0x15,
-	CMD_CDH_PROCESS_LED_TEST             = 0x16,
+	CMD_CDH_PROCESS_HEARTBEAT,
+	CMD_CDH_PROCESS_RUNTIME_ERROR,
+	CMD_CDH_PROCESS_COMMAND_ERROR,
+	CMD_CDH_PROCESS_NOTIFICATION,
+	CMD_CDH_PROCESS_TELEMETRY_REPORT,
+	CMD_CDH_PROCESS_RETURN,
+	CMD_CDH_PROCESS_LED_TEST,
 
 	// Clock
-	CMD_CDH_SET_RTC                      = 0x17,
-	CMD_CDH_GET_RTC                      = 0x18,
+	CMD_CDH_SET_RTC,
+	CMD_CDH_GET_RTC,
 
 	// Tests
-	CMD_CDH_TEST_FLASH                   = 0x19,
-	CMD_CDH_TEST_MRAM                    = 0x1A,
+	CMD_CDH_TEST_FLASH,
+	CMD_CDH_TEST_MRAM,
 
-	CMD_CDH_RESET_SUBSYSTEM              = 0x1B,
+	CMD_CDH_RESET_SUBSYSTEM,
 
 	// Antenna
-	CMD_CDH_ENABLE_ANTENNA               = 0x1C,
-	CMD_CDH_DEPLOY_ANTENNA               = 0x1D,
+	CMD_CDH_ENABLE_ANTENNA,
+	CMD_CDH_DEPLOY_ANTENNA,
 
 	////////////////////////////////////////////
 	/// POWER
 	////////////////////////////////////////////
-	CMD_PWR_PROCESS_HEARTBEAT            = 0x20,
-	CMD_PWR_SET_SUBSYSTEM_POWER          = 0x21,
-	CMD_PWR_GET_SUBSYSTEM_POWER          = 0x22,
-	CMD_PWR_SET_BATTERY_HEATER_POWER     = 0x23,
-	CMD_PWR_GET_BATTERY_HEATER_POWER     = 0x24,
-	CMD_PWR_SET_BATTERY_ACCESS           = 0x25,
-	CMD_PWR_GET_BATTERY_ACCESS           = 0x26,
+	CMD_PWR_PROCESS_HEARTBEAT,
+	CMD_PWR_SET_SUBSYSTEM_POWER,
+	CMD_PWR_GET_SUBSYSTEM_POWER,
+	CMD_PWR_SET_BATTERY_HEATER_POWER,
+	CMD_PWR_GET_BATTERY_HEATER_POWER,
+	CMD_PWR_SET_BATTERY_ACCESS,
+	CMD_PWR_GET_BATTERY_ACCESS,
 
 	////////////////////////////////////////////
 	/// ADCS
 	////////////////////////////////////////////
-	CMD_ADCS_SET_MAGNETORQUER_DIRECTION  = 0x30,
-	CMD_ADCS_GET_MAGNETORQUER_DIRECTION  = 0x31,
-	CMD_ADCS_SET_OPERATING_MODE          = 0x32,
-	CMD_ADCS_GET_OPERATING_MODE          = 0x33,
+	CMD_ADCS_SET_MAGNETORQUER_DIRECTION,
+	CMD_ADCS_GET_MAGNETORQUER_DIRECTION,
+	CMD_ADCS_SET_OPERATING_MODE,
+	CMD_ADCS_GET_OPERATING_MODE,
 
 	////////////////////////////////////////////
 	/// PAYLOAD
 	////////////////////////////////////////////
-	CMD_PLD_SET_ACTIVE_ENVS              = 0x40,
-	CMD_PLD_GET_ACTIVE_ENVS              = 0x41,
-	CMD_PLD_SET_SETPOINT                 = 0x42,
-	CMD_PLD_GET_SETPOINT                 = 0x43,
-	CMD_PLD_SET_TOLERANCE                = 0x44,
-	CMD_PLD_GET_TOLERANCE                = 0x45,
-	CMD_PLD_TEST_LEDS                    = 0x46,
+	CMD_PLD_SET_ACTIVE_ENVS,
+	CMD_PLD_GET_ACTIVE_ENVS,
+	CMD_PLD_SET_SETPOINT,
+	CMD_PLD_GET_SETPOINT,
+	CMD_PLD_SET_TOLERANCE,
+	CMD_PLD_GET_TOLERANCE,
+	CMD_PLD_TEST_LEDS,
 
 	////////////////////////////////////////////
 	/// GROUND STATION
 	////////////////////////////////////////////
-	CMD_GND_VERIFY_FLASH_TEST            = 0x50,
-	CMD_GND_VERIFY_MRAM_TEST             = 0x51,
-	CMD_GDN_VERIFY_CDH_NUM_TASKS         = 0x52,
-	CMD_GND_VERIFY_SAMPLE_TASK           = 0x53,
-	CMD_GND_VERIFY_RTC                   = 0x54,
+	CMD_GND_VERIFY_FLASH_TEST,
+	CMD_GND_VERIFY_MRAM_TEST,
+	CMD_GDN_VERIFY_CDH_NUM_TASKS,
+	CMD_GND_VERIFY_SAMPLE_TASK,
+	CMD_GND_VERIFY_RTC,
 } CmdID;
 
 typedef struct

--- a/Inc/tuk/can_wrapper/can_command_list.h
+++ b/Inc/tuk/can_wrapper/can_command_list.h
@@ -14,102 +14,82 @@
 
 typedef enum
 {
-	SENSOR_PCB_TEMP = 0,
-	SENSOR_MCU_TEMP,
-	SENSOR_PLD_WELL_TEMP,
-	SENSOR_PLD_WELL_LIGHT,
-} SensorID;
-
-typedef enum
-{
-	POWER_LINE_BATTERY = 0,
-	POWER_LINE_PAYLOAD,
-	POWER_LINE_ADCS
-} PowerLineID;
-
-typedef enum
-{
 	////////////////////////////////////////////
 	/// COMMON
 	////////////////////////////////////////////
-	CMD_PREPRARE_FOR_SHUTDOWN            = 0x00,
-	CMD_RESET                            = 0x01,
-	CMD_GET_PCB_TEMP                     = 0x02,
-	CMD_GET_MCU_TEMP                     = 0x03,
+	CMD_COMM_RESET                       = 0x00,
+	CMD_COMM_PREPARE_FOR_SHUTDOWN        = 0x01,
+	CMD_COMM_GET_TELEMETRY               = 0x02,
+	CMD_COMM_SET_TELEMETRY_INTERVAL      = 0x03,
+	CMD_COMM_GET_TELEMETRY_INTERVAL      = 0x04,
+	CMD_COMM_UPDATE_START                = 0x05,
+	CMD_COMM_UPDATE_LOAD                 = 0x06,
+	CMD_COMM_UPDATE_END                  = 0x07,
 
 	////////////////////////////////////////////
 	/// CDH
 	////////////////////////////////////////////
 	// Event Processing.
 	CMD_CDH_PROCESS_HEARTBEAT            = 0x10,
-	CMD_CDH_PROCESS_ERROR                = 0x11,
-	CMD_CDH_PROCESS_READY_FOR_SHUTDOWN   = 0x12,
-	CMD_CDH_PROCESS_STARTUP              = 0x13,
-	CMD_CDH_PROCESS_PCB_TEMP             = 0x14,
-	CMD_CDH_PROCESS_MCU_TEMP             = 0x15,
-	CMD_CDH_PROCESS_CONVERTER_STATUS     = 0x16,
-	CMD_CDH_PROCESS_BATTERY_VOLTAGE      = 0x17,
-	CMD_CDH_PROCESS_MAGNETIC_FIELD       = 0x18,
-	CMD_CDH_PROCESS_ANGULAR_VELOCITY     = 0x19,
-	CMD_CDH_PROCESS_WELL_LIGHT           = 0x1A,
-	CMD_CDH_PROCESS_WELL_TEMP            = 0x1B,
-	CMD_CDH_PROCESS_LED_TEST             = 0x1C,
+	CMD_CDH_PROCESS_RUNTIME_ERROR        = 0x11,
+	CMD_CDH_PROCESS_COMMAND_ERROR        = 0x12,
+	CMD_CDH_PROCESS_NOTIFICATION         = 0x13,
+	CMD_CDH_PROCESS_TELEMETRY_REPORT     = 0x14,
+	CMD_CDH_PROCESS_RETURN               = 0x15,
+	CMD_CDH_PROCESS_LED_TEST             = 0x16,
+
+	// Clock
+	CMD_CDH_SET_RTC                      = 0x17,
+	CMD_CDH_GET_RTC                      = 0x18,
 
 	// Tests
-	CMD_CDH_TEST_FLASH                   = 0x1D,
-	CMD_CDH_TEST_MRAM                    = 0x1E,
+	CMD_CDH_TEST_FLASH                   = 0x19,
+	CMD_CDH_TEST_MRAM                    = 0x1A,
+
+	CMD_CDH_RESET_SUBSYSTEM              = 0x1B,
 
 	// Antenna
-	CMD_CDH_ENABLE_ANTENNA_DEPLOYMENT    = 0x1F,
-	CMD_CDH_DEPLOY_ANTENNA               = 0x20,
-	CMD_CDH_TRANSMIT_UHF_BEACON          = 0x21,
-
-	// RTOS
-	CMD_CDH_GET_NUM_TASKS                = 0x22,
-	CMD_CDH_SCHEDULE_SAMPLE_TASK         = 0x23,
-
-	// CLock
-	CMD_CDH_SET_RTC                      = 0x24,
-	CMD_CDH_GET_RTC                      = 0x25,
-
-	CMD_CDH_SET_TELEMETRY_INTERVAL       = 0x26,
+	CMD_CDH_ENABLE_ANTENNA               = 0x1C,
+	CMD_CDH_DEPLOY_ANTENNA               = 0x1D,
 
 	////////////////////////////////////////////
 	/// POWER
 	////////////////////////////////////////////
-	CMD_PWR_SET_LINE_POWER               = 0x30,
-	CMD_PWR_SET_BATTERY_HEATER           = 0x31,
-	CMD_PWR_GET_CONVERTER_STATUS         = 0x32,
-	CMD_PWR_SET_TELEMETRY_INTERVAL       = 0x33,
+	CMD_PWR_PROCESS_HEARTBEAT            = 0x20,
+	CMD_PWR_SET_SUBSYSTEM_POWER          = 0x21,
+	CMD_PWR_GET_SUBSYSTEM_POWER          = 0x22,
+	CMD_PWR_SET_BATTERY_HEATER_POWER     = 0x23,
+	CMD_PWR_GET_BATTERY_HEATER_POWER     = 0x24,
+	CMD_PWR_SET_BATTERY_ACCESS           = 0x25,
+	CMD_PWR_GET_BATTERY_ACCESS           = 0x26,
 
 	////////////////////////////////////////////
 	/// ADCS
 	////////////////////////////////////////////
-	CMD_ADCS_SET_MAGNETORQUER_POWER      = 0x40,
-	CMD_ADCS_SET_MAGNETORQUER_DIRECTION  = 0x41,
-	CMD_ADCS_GET_MAGNETIC_FIELD          = 0x42,
-	CMD_ADCS_GET_ANGULAR_VELOCITY        = 0x43,
-	CMD_ADCS_SET_TELEMETRY_INTERVAL      = 0x44,
+	CMD_ADCS_SET_MAGNETORQUER_DIRECTION  = 0x30,
+	CMD_ADCS_GET_MAGNETORQUER_DIRECTION  = 0x31,
+	CMD_ADCS_SET_OPERATING_MODE          = 0x32,
+	CMD_ADCS_GET_OPERATING_MODE          = 0x33,
 
 	////////////////////////////////////////////
 	/// PAYLOAD
 	////////////////////////////////////////////
-	CMD_PLD_SET_WELL_LED                 = 0x50,
-	CMD_PLD_SET_WELL_HEATER              = 0x51,
-	CMD_PLD_SET_WELL_TEMP                = 0x52,
-	CMD_PLD_GET_WELL_TEMP                = 0x53,
-	CMD_PLD_GET_WELL_LIGHT               = 0x54,
-	CMD_PLD_SET_TELEMETRY_INTERVAL       = 0x55,
-	CMD_PLD_TEST_LEDS                    = 0x56,
+	CMD_PLD_SET_ACTIVE_ENVS              = 0x40,
+	CMD_PLD_GET_ACTIVE_ENVS              = 0x41,
+	CMD_PLD_SET_SETPOINT                 = 0x42,
+	CMD_PLD_GET_SETPOINT                 = 0x43,
+	CMD_PLD_SET_TOLERANCE                = 0x44,
+	CMD_PLD_GET_TOLERANCE                = 0x45,
+	CMD_PLD_TEST_LEDS                    = 0x46,
 
 	////////////////////////////////////////////
 	/// GROUND STATION
 	////////////////////////////////////////////
-	CMD_GND_VERIFY_FLASH_TEST            = 0x60,
-	CMD_GND_VERIFY_MRAM_TEST             = 0x61,
-	CMD_GDN_VERIFY_CDH_NUM_TASKS         = 0x62,
-	CMD_GND_VERIFY_SAMPLE_TASK           = 0x63,
-	CMD_GND_VERIFY_RTC                   = 0x64,
+	CMD_GND_VERIFY_FLASH_TEST            = 0x50,
+	CMD_GND_VERIFY_MRAM_TEST             = 0x51,
+	CMD_GDN_VERIFY_CDH_NUM_TASKS         = 0x52,
+	CMD_GND_VERIFY_SAMPLE_TASK           = 0x53,
+	CMD_GND_VERIFY_RTC                   = 0x54,
 } CmdID;
 
 typedef struct

--- a/Src/can_wrapper/can_command_list.c
+++ b/Src/can_wrapper/can_command_list.c
@@ -29,8 +29,8 @@ const CmdConfig cmd_configs[NUM_COMMANDS] = {
 		////////////////////////////////////////////
 		//CMD                                 //BODY SIZE //PRIORITY
 		[CMD_CDH_PROCESS_HEARTBEAT]            ={0, 2 },
-		[CMD_CDH_PROCESS_RUNTIME_ERROR]        ={2, 10},
-		[CMD_CDH_PROCESS_COMMAND_ERROR]        ={2, 10},
+		[CMD_CDH_PROCESS_RUNTIME_ERROR]        ={7, 10},
+		[CMD_CDH_PROCESS_COMMAND_ERROR]        ={7, 10},
 		[CMD_CDH_PROCESS_NOTIFICATION]         ={1, 2 },
 		[CMD_CDH_PROCESS_TELEMETRY_REPORT]     ={7, 3 },
 		[CMD_CDH_PROCESS_RETURN]               ={7, 32},

--- a/Src/can_wrapper/can_command_list.c
+++ b/Src/can_wrapper/can_command_list.c
@@ -9,73 +9,73 @@
 
 #include <tuk/can_wrapper/can_command_list.h>
 
-const CmdConfig cmd_configs[0x70] = {
+const CmdConfig cmd_configs[NUM_COMMANDS] = {
 		////////////////////////////////////////////
 		/// COMMON
 		////////////////////////////////////////////
 		//CMD                                 //BODY SIZE //PRIORITY
-		[CMD_COMM_RESET]                       ={0,   0 },
-		[CMD_COMM_PREPARE_FOR_SHUTDOWN]        ={0,   1 },
-		[CMD_COMM_GET_TELEMETRY]               ={1,   32},
-		[CMD_COMM_SET_TELEMETRY_INTERVAL]      ={3,   32},
-		[CMD_COMM_GET_TELEMETRY_INTERVAL]      ={1,   32},
-		[CMD_COMM_UPDATE_START]                ={4,   32},
-		[CMD_COMM_UPDATE_LOAD]                 ={7,   32},
-		[CMD_COMM_UPDATE_END]                  ={0,   32},
+		[CMD_COMM_RESET]                       ={0, 0 },
+		[CMD_COMM_PREPARE_FOR_SHUTDOWN]        ={0, 1 },
+		[CMD_COMM_GET_TELEMETRY]               ={1, 32},
+		[CMD_COMM_SET_TELEMETRY_INTERVAL]      ={3, 32},
+		[CMD_COMM_GET_TELEMETRY_INTERVAL]      ={1, 32},
+		[CMD_COMM_UPDATE_START]                ={4, 32},
+		[CMD_COMM_UPDATE_LOAD]                 ={7, 32},
+		[CMD_COMM_UPDATE_END]                  ={0, 32},
 
 		////////////////////////////////////////////
 		/// CDH
 		////////////////////////////////////////////
 		//CMD                                 //BODY SIZE //PRIORITY
-		[CMD_CDH_PROCESS_HEARTBEAT]            ={0,   2 },
-		[CMD_CDH_PROCESS_RUNTIME_ERROR]        ={2,   10},
-		[CMD_CDH_PROCESS_COMMAND_ERROR]        ={2,   10},
-		[CMD_CDH_PROCESS_NOTIFICATION]         ={1,   2 },
-		[CMD_CDH_PROCESS_TELEMETRY_REPORT]     ={7,   3 },
-		[CMD_CDH_PROCESS_RETURN]               ={1,   32}, // Remaining bytes correspond to cmd ID
-		[CMD_CDH_PROCESS_LED_TEST]             ={2,   4 },
+		[CMD_CDH_PROCESS_HEARTBEAT]            ={0, 2 },
+		[CMD_CDH_PROCESS_RUNTIME_ERROR]        ={2, 10},
+		[CMD_CDH_PROCESS_COMMAND_ERROR]        ={2, 10},
+		[CMD_CDH_PROCESS_NOTIFICATION]         ={1, 2 },
+		[CMD_CDH_PROCESS_TELEMETRY_REPORT]     ={7, 3 },
+		[CMD_CDH_PROCESS_RETURN]               ={7, 32},
+		[CMD_CDH_PROCESS_LED_TEST]             ={2, 4 },
 
-		[CMD_CDH_SET_RTC]                      ={4,   32},
-		[CMD_CDH_GET_RTC]                      ={0,   32},
+		[CMD_CDH_SET_RTC]                      ={4, 32},
+		[CMD_CDH_GET_RTC]                      ={0, 32},
 
-		[CMD_CDH_TEST_FLASH]                   ={0,   32},
-		[CMD_CDH_TEST_MRAM]                    ={0,   32},
+		[CMD_CDH_TEST_FLASH]                   ={0, 32},
+		[CMD_CDH_TEST_MRAM]                    ={0, 32},
 
-		[CMD_CDH_RESET_SUBSYSTEM]              ={4,   32},
+		[CMD_CDH_RESET_SUBSYSTEM]              ={4, 32},
 
-		[CMD_CDH_ENABLE_ANTENNA]               ={0,   32},
-		[CMD_CDH_DEPLOY_ANTENNA]               ={0,   32},
+		[CMD_CDH_ENABLE_ANTENNA]               ={0, 32},
+		[CMD_CDH_DEPLOY_ANTENNA]               ={0, 32},
 
 		////////////////////////////////////////////
 		/// POWER
 		////////////////////////////////////////////
 		//CMD                                 //BODY SIZE //PRIORITY
-		[CMD_PWR_PROCESS_HEARTBEAT]            ={0,   2 },
-		[CMD_PWR_SET_SUBSYSTEM_POWER]          ={5,   0 },
-		[CMD_PWR_GET_SUBSYSTEM_POWER]          ={4,   32},
-		[CMD_PWR_SET_BATTERY_HEATER_POWER]     ={1,   5 },
-		[CMD_PWR_GET_BATTERY_HEATER_POWER]     ={0,   32},
-		[CMD_PWR_SET_BATTERY_ACCESS]           ={1,   32},
-		[CMD_PWR_GET_BATTERY_ACCESS]           ={0,   32},
+		[CMD_PWR_PROCESS_HEARTBEAT]            ={0, 2 },
+		[CMD_PWR_SET_SUBSYSTEM_POWER]          ={5, 0 },
+		[CMD_PWR_GET_SUBSYSTEM_POWER]          ={4, 32},
+		[CMD_PWR_SET_BATTERY_HEATER_POWER]     ={1, 5 },
+		[CMD_PWR_GET_BATTERY_HEATER_POWER]     ={0, 32},
+		[CMD_PWR_SET_BATTERY_ACCESS]           ={1, 32},
+		[CMD_PWR_GET_BATTERY_ACCESS]           ={0, 32},
 
 		////////////////////////////////////////////
 		/// ADCS
 		////////////////////////////////////////////
 		//CMD                                 //BODY SIZE //PRIORITY
-		[CMD_ADCS_SET_MAGNETORQUER_DIRECTION]  ={2,   32},
-		[CMD_ADCS_GET_MAGNETORQUER_DIRECTION]  ={1,   32},
-		[CMD_ADCS_SET_OPERATING_MODE]          ={1,   32},
-		[CMD_ADCS_GET_OPERATING_MODE]          ={0,   32},
+		[CMD_ADCS_SET_MAGNETORQUER_DIRECTION]  ={2, 32},
+		[CMD_ADCS_GET_MAGNETORQUER_DIRECTION]  ={1, 32},
+		[CMD_ADCS_SET_OPERATING_MODE]          ={1, 32},
+		[CMD_ADCS_GET_OPERATING_MODE]          ={0, 32},
 
 		////////////////////////////////////////////
 		/// PAYLOAD
 		////////////////////////////////////////////
 		//CMD                                 //BODY SIZE //PRIORITY
-		[CMD_PLD_SET_ACTIVE_ENVS]              ={2,   32},
-		[CMD_PLD_GET_ACTIVE_ENVS]              ={0,   32},
-		[CMD_PLD_SET_SETPOINT]                 ={5,   32}, // confirm float = 4B
-		[CMD_PLD_GET_SETPOINT]                 ={1,   32},
-		[CMD_PLD_SET_TOLERANCE]                ={4,   32}, // confirm float = 4B
-		[CMD_PLD_GET_TOLERANCE]                ={0,   32},
-		[CMD_PLD_TEST_LEDS]                    ={0,   4 },
+		[CMD_PLD_SET_ACTIVE_ENVS]              ={2, 32},
+		[CMD_PLD_GET_ACTIVE_ENVS]              ={0, 32},
+		[CMD_PLD_SET_SETPOINT]                 ={5, 32},
+		[CMD_PLD_GET_SETPOINT]                 ={1, 32},
+		[CMD_PLD_SET_TOLERANCE]                ={4, 32},
+		[CMD_PLD_GET_TOLERANCE]                ={0, 32},
+		[CMD_PLD_TEST_LEDS]                    ={0, 4 },
 };

--- a/Src/can_wrapper/can_command_list.c
+++ b/Src/can_wrapper/can_command_list.c
@@ -10,76 +10,72 @@
 #include <tuk/can_wrapper/can_command_list.h>
 
 const CmdConfig cmd_configs[0x70] = {
-		//////////////////////////////////////////////////////////////
+		////////////////////////////////////////////
 		/// COMMON
-		//////////////////////////////////////////////////////////////
-		///CMD                                 //BODY SIZE //PRIORITY
-		[CMD_PREPRARE_FOR_SHUTDOWN]            ={0,   0b000000       },
-		[CMD_RESET]                            ={0,   0b000001       },
-		[CMD_GET_PCB_TEMP]                     ={0,   0b001111       },
-		[CMD_GET_MCU_TEMP]                     ={0,   0b001111       },
+		////////////////////////////////////////////
+		//CMD                                 //BODY SIZE //PRIORITY
+		[CMD_COMM_RESET]                       ={0,   0b000000       },
+		[CMD_COMM_PREPARE_FOR_SHUTDOWN]        ={0,   0b000001       },
+		[CMD_COMM_GET_TELEMETRY]               ={1,   0b100000       },
+		[CMD_COMM_SET_TELEMETRY_INTERVAL]      ={3,   0b100000       },
+		[CMD_COMM_GET_TELEMETRY_INTERVAL]      ={1,   0b100000       },
+		[CMD_COMM_UPDATE_START]                ={4,   0b100000       },
+		[CMD_COMM_UPDATE_LOAD]                 ={7,   0b100000       },
+		[CMD_COMM_UPDATE_END]                  ={0,   0b100000       },
 
-		//////////////////////////////////////////////////////////////
+		////////////////////////////////////////////
 		/// CDH
-		//////////////////////////////////////////////////////////////
-		///CMD                                 //BODY SIZE //PRIORITY
-		[CMD_CDH_PROCESS_HEARTBEAT]            ={0,   0b000001       },
-		[CMD_CDH_PROCESS_ERROR]                ={7,   0b000001       },
-		[CMD_CDH_PROCESS_READY_FOR_SHUTDOWN]   ={0,   0b000001       },
-		[CMD_CDH_PROCESS_STARTUP]              ={0,   0b000001       },
-		[CMD_CDH_PROCESS_PCB_TEMP]             ={2,   0b001111       },
-		[CMD_CDH_PROCESS_MCU_TEMP]             ={2,   0b001111       },
-		[CMD_CDH_PROCESS_CONVERTER_STATUS]     ={1,   0b011111       },
-		[CMD_CDH_PROCESS_BATTERY_VOLTAGE]      ={0,   0b011111       },
-		[CMD_CDH_PROCESS_MAGNETIC_FIELD]       ={7,   0b111111       },
-		[CMD_CDH_PROCESS_ANGULAR_VELOCITY]     ={7,   0b111111       },
-		[CMD_CDH_PROCESS_WELL_LIGHT]           ={3,   0b011111       },
-		[CMD_CDH_PROCESS_WELL_TEMP]            ={3,   0b011111       },
-		[CMD_CDH_PROCESS_LED_TEST]             ={2,   0b111111       },
+		////////////////////////////////////////////
+		//CMD                                 //BODY SIZE //PRIORITY
+		[CMD_CDH_PROCESS_HEARTBEAT]            ={0,   0b000010       },
+		[CMD_CDH_PROCESS_RUNTIME_ERROR]        ={2,   0b001010       },
+		[CMD_CDH_PROCESS_COMMAND_ERROR]        ={2,   0b001010       },
+		[CMD_CDH_PROCESS_NOTIFICATION]         ={1,   0b000010       },
+		[CMD_CDH_PROCESS_TELEMETRY_REPORT]     ={7,   0b000011       },
+		[CMD_CDH_PROCESS_RETURN]               ={1,   0b100000       }, // Remaining bytes correspond to cmd ID
+		[CMD_CDH_PROCESS_LED_TEST]             ={2,   0b000100       },
 
-		[CMD_CDH_TEST_FLASH]                   ={0,   0b111111       },
-		[CMD_CDH_TEST_MRAM]                    ={0,   0b111111       },
+		[CMD_CDH_SET_RTC]                      ={4,   0b100000       },
+		[CMD_CDH_GET_RTC]                      ={0,   0b100000       },
 
-		[CMD_CDH_ENABLE_ANTENNA_DEPLOYMENT]    ={0,   0b000000       },
-		[CMD_CDH_DEPLOY_ANTENNA]               ={0,   0b000000       },
-		[CMD_CDH_TRANSMIT_UHF_BEACON]          ={0,   0b000111       },
+		[CMD_CDH_TEST_FLASH]                   ={0,   0b100000       },
+		[CMD_CDH_TEST_MRAM]                    ={0,   0b100000       },
 
-		[CMD_CDH_GET_NUM_TASKS]                ={0,   0b111111       },
-		[CMD_CDH_SCHEDULE_SAMPLE_TASK]         ={4,   0b000111       },
+		[CMD_CDH_RESET_SUBSYSTEM]              ={4,   0b100000       },
 
-		[CMD_CDH_SET_RTC]                      ={4,   0b000111       },
-		[CMD_CDH_GET_RTC]                      ={0,   0b111111       },
+		[CMD_CDH_ENABLE_ANTENNA]               ={0,   0b100000       },
+		[CMD_CDH_DEPLOY_ANTENNA]               ={0,   0b100000       },
 
-		[CMD_CDH_SET_TELEMETRY_INTERVAL]       ={3,   0b000111       },
-
-		//////////////////////////////////////////////////////////////
+		////////////////////////////////////////////
 		/// POWER
-		//////////////////////////////////////////////////////////////
-		///CMD                                 //BODY SIZE //PRIORITY
-		[CMD_PWR_SET_LINE_POWER]               ={2,   0b000001       },
-		[CMD_PWR_SET_BATTERY_HEATER]           ={1,   0b000011       },
-		[CMD_PWR_GET_CONVERTER_STATUS]         ={0,   0b000111       },
-		[CMD_PWR_SET_TELEMETRY_INTERVAL]       ={3,   0b000111       },
+		////////////////////////////////////////////
+		//CMD                                 //BODY SIZE //PRIORITY
+		[CMD_PWR_PROCESS_HEARTBEAT]            ={0,   0b000010       },
+		[CMD_PWR_SET_SUBSYSTEM_POWER]          ={5,   0b000000       },
+		[CMD_PWR_GET_SUBSYSTEM_POWER]          ={4,   0b100000       },
+		[CMD_PWR_SET_BATTERY_HEATER_POWER]     ={1,   0b000101       },
+		[CMD_PWR_GET_BATTERY_HEATER_POWER]     ={0,   0b100000       },
+		[CMD_PWR_SET_BATTERY_ACCESS]           ={1,   0b100000       },
+		[CMD_PWR_GET_BATTERY_ACCESS]           ={0,   0b100000       },
 
-		//////////////////////////////////////////////////////////////
+		////////////////////////////////////////////
 		/// ADCS
-		//////////////////////////////////////////////////////////////
-		///CMD                                 //BODY SIZE //PRIORITY
-		[CMD_ADCS_SET_MAGNETORQUER_POWER]      ={2,   0b111111       },
-		[CMD_ADCS_SET_MAGNETORQUER_DIRECTION]  ={2,   0b111111       },
-		[CMD_ADCS_GET_MAGNETIC_FIELD]          ={1,   0b111111       },
-		[CMD_ADCS_GET_ANGULAR_VELOCITY]        ={1,   0b111111       },
-		[CMD_ADCS_SET_TELEMETRY_INTERVAL]      ={3,   0b000111       },
+		////////////////////////////////////////////
+		//CMD                                 //BODY SIZE //PRIORITY
+		[CMD_ADCS_SET_MAGNETORQUER_DIRECTION]  ={2,   0b100000       },
+		[CMD_ADCS_GET_MAGNETORQUER_DIRECTION]  ={1,   0b100000       },
+		[CMD_ADCS_SET_OPERATING_MODE]          ={1,   0b100000       },
+		[CMD_ADCS_GET_OPERATING_MODE]          ={0,   0b100000       },
 
-		//////////////////////////////////////////////////////////////
+		////////////////////////////////////////////
 		/// PAYLOAD
-		//////////////////////////////////////////////////////////////
-		///CMD                                 //BODY SIZE //PRIORITY
-		[CMD_PLD_SET_WELL_LED]                 ={2,   0b001111       },
-		[CMD_PLD_SET_WELL_HEATER]              ={2,   0b000111       },
-		[CMD_PLD_SET_WELL_TEMP]                ={3,   0b001111       },
-		[CMD_PLD_GET_WELL_TEMP]                ={1,   0b001111       },
-		[CMD_PLD_GET_WELL_LIGHT]               ={1,   0b011111       },
-		[CMD_PLD_SET_TELEMETRY_INTERVAL]       ={4,   0b000111       },
-		[CMD_PLD_TEST_LEDS]                    ={0,   0b000111       },
+		////////////////////////////////////////////
+		//CMD                                 //BODY SIZE //PRIORITY
+		[CMD_PLD_SET_ACTIVE_ENVS]              ={2,   0b100000       },
+		[CMD_PLD_GET_ACTIVE_ENVS]              ={0,   0b100000       },
+		[CMD_PLD_SET_SETPOINT]                 ={5,   0b100000       }, // confirm float = 4B
+		[CMD_PLD_GET_SETPOINT]                 ={1,   0b100000       },
+		[CMD_PLD_SET_TOLERANCE]                ={4,   0b100000       }, // confirm float = 4B
+		[CMD_PLD_GET_TOLERANCE]                ={0,   0b100000       },
+		[CMD_PLD_TEST_LEDS]                    ={0,   0b000100       },
 };

--- a/Src/can_wrapper/can_command_list.c
+++ b/Src/can_wrapper/can_command_list.c
@@ -3,6 +3,7 @@
  * Configurations for all valid command ID's.
  *
  * @author Logan Furedi <logan.furedi@umsats.ca>
+ * @author Arnav Gupta <arnav.gupta@umsats.ca>
  *
  * @date March 16, 2024
  */

--- a/Src/can_wrapper/can_command_list.c
+++ b/Src/can_wrapper/can_command_list.c
@@ -14,68 +14,68 @@ const CmdConfig cmd_configs[0x70] = {
 		/// COMMON
 		////////////////////////////////////////////
 		//CMD                                 //BODY SIZE //PRIORITY
-		[CMD_COMM_RESET]                       ={0,   0b000000       },
-		[CMD_COMM_PREPARE_FOR_SHUTDOWN]        ={0,   0b000001       },
-		[CMD_COMM_GET_TELEMETRY]               ={1,   0b100000       },
-		[CMD_COMM_SET_TELEMETRY_INTERVAL]      ={3,   0b100000       },
-		[CMD_COMM_GET_TELEMETRY_INTERVAL]      ={1,   0b100000       },
-		[CMD_COMM_UPDATE_START]                ={4,   0b100000       },
-		[CMD_COMM_UPDATE_LOAD]                 ={7,   0b100000       },
-		[CMD_COMM_UPDATE_END]                  ={0,   0b100000       },
+		[CMD_COMM_RESET]                       ={0,   0 },
+		[CMD_COMM_PREPARE_FOR_SHUTDOWN]        ={0,   1 },
+		[CMD_COMM_GET_TELEMETRY]               ={1,   32},
+		[CMD_COMM_SET_TELEMETRY_INTERVAL]      ={3,   32},
+		[CMD_COMM_GET_TELEMETRY_INTERVAL]      ={1,   32},
+		[CMD_COMM_UPDATE_START]                ={4,   32},
+		[CMD_COMM_UPDATE_LOAD]                 ={7,   32},
+		[CMD_COMM_UPDATE_END]                  ={0,   32},
 
 		////////////////////////////////////////////
 		/// CDH
 		////////////////////////////////////////////
 		//CMD                                 //BODY SIZE //PRIORITY
-		[CMD_CDH_PROCESS_HEARTBEAT]            ={0,   0b000010       },
-		[CMD_CDH_PROCESS_RUNTIME_ERROR]        ={2,   0b001010       },
-		[CMD_CDH_PROCESS_COMMAND_ERROR]        ={2,   0b001010       },
-		[CMD_CDH_PROCESS_NOTIFICATION]         ={1,   0b000010       },
-		[CMD_CDH_PROCESS_TELEMETRY_REPORT]     ={7,   0b000011       },
-		[CMD_CDH_PROCESS_RETURN]               ={1,   0b100000       }, // Remaining bytes correspond to cmd ID
-		[CMD_CDH_PROCESS_LED_TEST]             ={2,   0b000100       },
+		[CMD_CDH_PROCESS_HEARTBEAT]            ={0,   2 },
+		[CMD_CDH_PROCESS_RUNTIME_ERROR]        ={2,   10},
+		[CMD_CDH_PROCESS_COMMAND_ERROR]        ={2,   10},
+		[CMD_CDH_PROCESS_NOTIFICATION]         ={1,   2 },
+		[CMD_CDH_PROCESS_TELEMETRY_REPORT]     ={7,   3 },
+		[CMD_CDH_PROCESS_RETURN]               ={1,   32}, // Remaining bytes correspond to cmd ID
+		[CMD_CDH_PROCESS_LED_TEST]             ={2,   4 },
 
-		[CMD_CDH_SET_RTC]                      ={4,   0b100000       },
-		[CMD_CDH_GET_RTC]                      ={0,   0b100000       },
+		[CMD_CDH_SET_RTC]                      ={4,   32},
+		[CMD_CDH_GET_RTC]                      ={0,   32},
 
-		[CMD_CDH_TEST_FLASH]                   ={0,   0b100000       },
-		[CMD_CDH_TEST_MRAM]                    ={0,   0b100000       },
+		[CMD_CDH_TEST_FLASH]                   ={0,   32},
+		[CMD_CDH_TEST_MRAM]                    ={0,   32},
 
-		[CMD_CDH_RESET_SUBSYSTEM]              ={4,   0b100000       },
+		[CMD_CDH_RESET_SUBSYSTEM]              ={4,   32},
 
-		[CMD_CDH_ENABLE_ANTENNA]               ={0,   0b100000       },
-		[CMD_CDH_DEPLOY_ANTENNA]               ={0,   0b100000       },
+		[CMD_CDH_ENABLE_ANTENNA]               ={0,   32},
+		[CMD_CDH_DEPLOY_ANTENNA]               ={0,   32},
 
 		////////////////////////////////////////////
 		/// POWER
 		////////////////////////////////////////////
 		//CMD                                 //BODY SIZE //PRIORITY
-		[CMD_PWR_PROCESS_HEARTBEAT]            ={0,   0b000010       },
-		[CMD_PWR_SET_SUBSYSTEM_POWER]          ={5,   0b000000       },
-		[CMD_PWR_GET_SUBSYSTEM_POWER]          ={4,   0b100000       },
-		[CMD_PWR_SET_BATTERY_HEATER_POWER]     ={1,   0b000101       },
-		[CMD_PWR_GET_BATTERY_HEATER_POWER]     ={0,   0b100000       },
-		[CMD_PWR_SET_BATTERY_ACCESS]           ={1,   0b100000       },
-		[CMD_PWR_GET_BATTERY_ACCESS]           ={0,   0b100000       },
+		[CMD_PWR_PROCESS_HEARTBEAT]            ={0,   2 },
+		[CMD_PWR_SET_SUBSYSTEM_POWER]          ={5,   0 },
+		[CMD_PWR_GET_SUBSYSTEM_POWER]          ={4,   32},
+		[CMD_PWR_SET_BATTERY_HEATER_POWER]     ={1,   5 },
+		[CMD_PWR_GET_BATTERY_HEATER_POWER]     ={0,   32},
+		[CMD_PWR_SET_BATTERY_ACCESS]           ={1,   32},
+		[CMD_PWR_GET_BATTERY_ACCESS]           ={0,   32},
 
 		////////////////////////////////////////////
 		/// ADCS
 		////////////////////////////////////////////
 		//CMD                                 //BODY SIZE //PRIORITY
-		[CMD_ADCS_SET_MAGNETORQUER_DIRECTION]  ={2,   0b100000       },
-		[CMD_ADCS_GET_MAGNETORQUER_DIRECTION]  ={1,   0b100000       },
-		[CMD_ADCS_SET_OPERATING_MODE]          ={1,   0b100000       },
-		[CMD_ADCS_GET_OPERATING_MODE]          ={0,   0b100000       },
+		[CMD_ADCS_SET_MAGNETORQUER_DIRECTION]  ={2,   32},
+		[CMD_ADCS_GET_MAGNETORQUER_DIRECTION]  ={1,   32},
+		[CMD_ADCS_SET_OPERATING_MODE]          ={1,   32},
+		[CMD_ADCS_GET_OPERATING_MODE]          ={0,   32},
 
 		////////////////////////////////////////////
 		/// PAYLOAD
 		////////////////////////////////////////////
 		//CMD                                 //BODY SIZE //PRIORITY
-		[CMD_PLD_SET_ACTIVE_ENVS]              ={2,   0b100000       },
-		[CMD_PLD_GET_ACTIVE_ENVS]              ={0,   0b100000       },
-		[CMD_PLD_SET_SETPOINT]                 ={5,   0b100000       }, // confirm float = 4B
-		[CMD_PLD_GET_SETPOINT]                 ={1,   0b100000       },
-		[CMD_PLD_SET_TOLERANCE]                ={4,   0b100000       }, // confirm float = 4B
-		[CMD_PLD_GET_TOLERANCE]                ={0,   0b100000       },
-		[CMD_PLD_TEST_LEDS]                    ={0,   0b000100       },
+		[CMD_PLD_SET_ACTIVE_ENVS]              ={2,   32},
+		[CMD_PLD_GET_ACTIVE_ENVS]              ={0,   32},
+		[CMD_PLD_SET_SETPOINT]                 ={5,   32}, // confirm float = 4B
+		[CMD_PLD_GET_SETPOINT]                 ={1,   32},
+		[CMD_PLD_SET_TOLERANCE]                ={4,   32}, // confirm float = 4B
+		[CMD_PLD_GET_TOLERANCE]                ={0,   32},
+		[CMD_PLD_TEST_LEDS]                    ={0,   4 },
 };


### PR DESCRIPTION
Updates `can_command_list.h` and `can_command_list.c` to match the command list found [here](https://docs.google.com/spreadsheets/d/1fF_nCTbqJ7y3KoorSmB4DAGctDv61TSHfD0VK8CovCM/edit?gid=1728821240#gid=1728821240).

Changes:
- Removes enum value assignments from `CmdID`
- Defines `NUM_COMMANDS` to be used for the size of `cmd_configs`
