### PR TITLE
feat: add more metadata to message callback

### DIFF
--- a/Inc/tuk/can_wrapper/can_command_list.h
+++ b/Inc/tuk/can_wrapper/can_command_list.h
@@ -10,6 +10,7 @@
 #include "telemetry_id.h"
 
 #include <stdint.h>
+#include <assert.h>
 
 // Used in the PROCESS_NOTIFICATION command.
 typedef enum
@@ -93,6 +94,7 @@ typedef enum
 
 	NUM_COMMANDS
 } CmdID;
+_Static_assert(sizeof(CmdID) == 1, "Enum size exceeds 1 byte");
 
 typedef struct
 {

--- a/Inc/tuk/can_wrapper/can_message.h
+++ b/Inc/tuk/can_wrapper/can_message.h
@@ -12,6 +12,7 @@
 #include <stdint.h>
 #include <stdbool.h>
 #include <string.h>
+#include <assert.h>
 
 #define CAN_MAX_BODY_SIZE 7
 
@@ -22,32 +23,22 @@ typedef enum
 	NODE_ADCS    = 2,
 	NODE_PAYLOAD = 3
 } NodeID;
+_Static_assert(sizeof(NodeID) == 1, "Enum size exceeds 1 byte");
 
 typedef struct
 {
-	uint8_t cmd;
+	CmdID cmd;
 	uint8_t body[CAN_MAX_BODY_SIZE];
-} CANMessage;
-
-typedef struct
-{
-	CANMessage msg;
 	uint8_t priority;
-	uint8_t sender;
-	uint8_t recipient;
+	NodeID sender;
+	NodeID recipient;
 	uint8_t is_ack;
-} CachedCANMessage;
-
-static inline bool CANMessage_Equals(const CANMessage *msg1, const CANMessage *msg2)
-{
-	return msg1->cmd == msg2->cmd
-			&& memcmp(msg1->body, msg2->body, cmd_configs[msg1->cmd].body_size) == 0;
-}
+} CANMessage;
 
 // Macros to get & set arguments in a command.
 // NOTE: These assume consistent endianness across subsystems. If a subsystem
 // switches to a big-endian processor, that subsystem will have to perform a
-// byte swap.
+// byte swap of the message contents.
 
 // Example Usage: float arg = GET_ARG(msg, 0, float);
 #define GET_ARG(msg, pos, type) ({ \

--- a/Inc/tuk/can_wrapper/can_queue.h
+++ b/Inc/tuk/can_wrapper/can_queue.h
@@ -9,6 +9,7 @@
 #define CAN_WRAPPER_MODULE_INC_CAN_QUEUE_H_
 
 #include "can_message.h"
+
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -16,7 +17,7 @@
 
 typedef struct
 {
-	CachedCANMessage msg;
+	CANMessage msg;
 } CANQueueItem;
 
 typedef struct

--- a/Inc/tuk/can_wrapper/can_wrapper.h
+++ b/Inc/tuk/can_wrapper/can_wrapper.h
@@ -37,7 +37,7 @@ typedef enum
 	CAN_WRAPPER_TX_MAILBOXES_FULL
 } CANWrapper_StatusTypeDef;
 
-typedef void (*CANMessageCallback)(CANMessage, NodeID, bool);
+typedef void (*CANMessageCallback)(CANMessage);
 typedef void (*CANErrorCallback)(CANWrapper_ErrorInfo);
 
 typedef struct
@@ -53,7 +53,7 @@ typedef struct
 } CANWrapper_InitTypeDef;
 
 /**
- * @brief				Performs necessary setup for normal functioning.
+ * @brief               Performs necessary setup for normal functioning.
  *
  * @param init_struct   Configuration for initialisation.
  */
@@ -81,6 +81,6 @@ CANWrapper_StatusTypeDef CANWrapper_Poll_Errors();
  * @param recipient     ID of the intended recipient.
  * @param msg           See CANMessage definition.
  */
-CANWrapper_StatusTypeDef CANWrapper_Transmit(NodeID recipient, CANMessage *msg);
+CANWrapper_StatusTypeDef CANWrapper_Transmit(NodeID recipient, const CANMessage *msg);
 
 #endif /* CAN_WRAPPER_MODULE_INC_CAN_WRAPPER_H_ */

--- a/Inc/tuk/can_wrapper/error_info.h
+++ b/Inc/tuk/can_wrapper/error_info.h
@@ -16,10 +16,7 @@ typedef struct
 	} error;
 	union
 	{
-		struct {
-			CANMessage msg;
-			NodeID recipient;
-		};
+		CANMessage msg;
 		// TODO: more error information.
 	};
 } CANWrapper_ErrorInfo;

--- a/Inc/tuk/can_wrapper/tx_cache.h
+++ b/Inc/tuk/can_wrapper/tx_cache.h
@@ -23,7 +23,7 @@ typedef struct
 		uint32_t counter_value;
 		uint32_t rcr_value;
 	} timestamp;
-	CachedCANMessage msg;
+	CANMessage msg;
 } TxCacheItem;
 
 typedef struct
@@ -40,7 +40,7 @@ bool TxCache_IsFull(const TxCache* txc);
 
 bool TxCache_Push_Back(TxCache *txc, TxCacheItem *item);
 
-int TxCache_Find(const TxCache *txc, const CachedCANMessage *ack);
+int TxCache_Find(const TxCache *txc, const CANMessage *ack);
 
 bool TxCache_Erase(TxCache *txc, int index);
 


### PR DESCRIPTION
Changes:
 * Updated the CANMessage struct definition.
 * Added static asserts to enums used therein.
 * Removed CachedCanMessage type and replaced all references to CANMessages.

Style:
 * Improved code readability in some parts & added comments.

Fixes:
 * Discovered a bug in HAL_CAN_RxFifo0MsgPendingCallback:
     * The CANQueueItem's recipient & priority fields weren't being set, which would have (haven't tested) caused the message to be enqueued with recipients and priorities of zero, messing with the detection of ACKs as a result.
     * Fixed by assigning all the fields immediately after reading the RX header.

Closes #41.