### PR TITLE
33 ensure all enum types are 8 bits wide

### DIFF
--- a/Inc/tuk/can_wrapper/can_command_list.h
+++ b/Inc/tuk/can_wrapper/can_command_list.h
@@ -19,7 +19,8 @@ typedef enum
 	NOTIFICATION_PREPARING_FOR_SHUTDOWN,
 	NOTIFICATION_READY_FOR_SHUTDOWN
 } NotificationID;
-_Static_assert(sizeof(NotificationID) == 8, "Enum size is not 8 bytes");
+_Static_assert(sizeof(NotificationID) == 1, "Enum size is not 8 bits");
+
 // NOTE: If you modify this list, you MUST update the command configurations to
 // reflect your changes.
 typedef enum

--- a/Inc/tuk/can_wrapper/can_command_list.h
+++ b/Inc/tuk/can_wrapper/can_command_list.h
@@ -19,7 +19,7 @@ typedef enum
 	NOTIFICATION_PREPARING_FOR_SHUTDOWN,
 	NOTIFICATION_READY_FOR_SHUTDOWN
 } NotificationID;
-
+_Static_assert(sizeof(NotificationID) == 8, "Enum size is not 8 bytes");
 // NOTE: If you modify this list, you MUST update the command configurations to
 // reflect your changes.
 typedef enum

--- a/Inc/tuk/can_wrapper/can_message.h
+++ b/Inc/tuk/can_wrapper/can_message.h
@@ -23,7 +23,8 @@ typedef enum
 	NODE_ADCS    = 2,
 	NODE_PAYLOAD = 3
 } NodeID;
-_Static_assert(sizeof(NodeID) == 1, "Enum size exceeds 1 byte");
+_Static_assert(sizeof(NodeID) == 1, "Enum size is not 8 bits");
+
 
 #define NODE_ID_MAX 3
 

--- a/Inc/tuk/can_wrapper/can_wrapper.h
+++ b/Inc/tuk/can_wrapper/can_wrapper.h
@@ -36,6 +36,7 @@ typedef enum
 	CAN_WRAPPER_TX_FAIL_BAD_CAN_STATE,
 	CAN_WRAPPER_TX_MAILBOXES_FULL
 } CANWrapper_StatusTypeDef;
+_Static_assert(sizeof(CANWrapper_StatusTypeDef) == 8, "Enum size is not 8 bytes");
 
 typedef void (*CANMessageCallback)(CANMessage);
 typedef void (*CANErrorCallback)(CANWrapper_ErrorInfo);

--- a/Inc/tuk/can_wrapper/can_wrapper.h
+++ b/Inc/tuk/can_wrapper/can_wrapper.h
@@ -36,7 +36,7 @@ typedef enum
 	CAN_WRAPPER_TX_FAIL_BAD_CAN_STATE,
 	CAN_WRAPPER_TX_MAILBOXES_FULL
 } CANWrapper_StatusTypeDef;
-_Static_assert(sizeof(CANWrapper_StatusTypeDef) == 8, "Enum size is not 8 bytes");
+_Static_assert(sizeof(CANWrapper_StatusTypeDef) == 1, "Enum size is not 8 bits");
 
 typedef void (*CANMessageCallback)(CANMessage);
 typedef void (*CANErrorCallback)(CANWrapper_ErrorInfo);

--- a/Inc/tuk/error_list.h
+++ b/Inc/tuk/error_list.h
@@ -46,4 +46,6 @@ typedef enum {
 	ERR_PLD_TCA9548_SET_CHANNEL,
 } ErrorID;
 
+_Static_assert(sizeof(ErrorID) == 8, "Enum size is not 8 bytes");
+
 #endif /* TSAT_UTILITIES_KIT_INC_TUK_ERROR_TRACKER_ERROR_LIST_H_ */

--- a/Inc/tuk/error_list.h
+++ b/Inc/tuk/error_list.h
@@ -46,6 +46,6 @@ typedef enum {
 	ERR_PLD_TCA9548_SET_CHANNEL,
 } ErrorID;
 
-_Static_assert(sizeof(ErrorID) == 8, "Enum size is not 8 bytes");
+_Static_assert(sizeof(ErrorID) == 1, "Enum size is not 8 bits");
 
 #endif /* TSAT_UTILITIES_KIT_INC_TUK_ERROR_TRACKER_ERROR_LIST_H_ */

--- a/Src/can_wrapper/tx_cache.c
+++ b/Src/can_wrapper/tx_cache.c
@@ -86,7 +86,7 @@ const TxCacheItem *TxCache_At(const TxCache *txc, int index)
  *
  * A match signifies:
  * 1. the message data and priority fields are identical
- * 2. the sender of msg is the recipient of ack, and
+ * 2. the sender of msg is the recipient of ack, and,
  * 3. the recipient of ack is the sender of msg.
  *
  * @param msg  the message.

--- a/Src/can_wrapper/tx_cache.c
+++ b/Src/can_wrapper/tx_cache.c
@@ -85,7 +85,7 @@ const TxCacheItem *TxCache_At(const TxCache *txc, int index)
  * @brief Returns true if the ACK message corresponds to msg.
  *
  * A match signifies:
- * 1. the message data and priority fields are identical,
+ * 1. the message data and priority fields are identical
  * 2. the sender of msg is the recipient of ack, and
  * 3. the recipient of ack is the sender of msg.
  *


### PR DESCRIPTION
I also did not assert the size for structs, because the task only specified enums, and i also assumed that different structs have different sizes.

 Used static assert where there was none 
Did not use if the size of other enums were already being checked